### PR TITLE
Dealing with new rounds

### DIFF
--- a/F3FChrono/data/Event.py
+++ b/F3FChrono/data/Event.py
@@ -129,6 +129,8 @@ class Event:
         self._competitors[bib_number] = Competitor.register_pilot(self, bib_number, pilot, team)
 
     def get_current_round(self):
+        if len(self.rounds) < 1:
+            self.create_new_round()
         return self.rounds[self.current_round]
 
     def get_competitor(self, bib_number):

--- a/F3FChrono/data/Round.py
+++ b/F3FChrono/data/Round.py
@@ -68,7 +68,10 @@ class Round:
         self._current_competitor_index = self._flight_order.index(competitor.bib_number)
 
     def next_pilot(self):
-        #TODO : detect end of round
         if self._current_competitor_index < len(self._flight_order) - 1:
             self._current_competitor_index += 1
-        return self.get_current_competitor()
+            return self.get_current_competitor()
+        else:
+            return None
+
+

--- a/F3FChrono/gui/MainUiController.py
+++ b/F3FChrono/gui/MainUiController.py
@@ -58,7 +58,11 @@ class MainUiCtrl (QtWidgets.QMainWindow):
         print(self.MainWindow.size())
 
     def next_pilot(self):
-        self.controllers['round'].wPilotCtrl.set_data(self.event.get_current_round().next_pilot())
+        next_pilot = self.event.get_current_round().next_pilot()
+        if next_pilot is None:
+            self.event.create_new_round()
+            next_pilot = self.event.get_current_round().get_current_competitor()
+        self.controllers['round'].wPilotCtrl.set_data(next_pilot)
         self.controllers['round'].wChronoCtrl.reset_ui()
 
     def refly(self):


### PR DESCRIPTION
This pull request should fix issues #12 and #14, dealing with end of round.



Testing done :

- When importing Col de Faisses, new round is created and pilot with bib 1 should fly
- New event created with the code below is correctly opened
```
from F3FChrono.data.Event import Event
from F3FChrono.data.Pilot import Pilot
from F3FChrono.data.dao.EventDAO import EventDAO
from F3FChrono.data.dao.CompetitorDAO import CompetitorDAO
import datetime

new_event = Event()
new_event.location = 'Brie'
new_event.name = 'Test'
new_event.begin_date = datetime.datetime.now()
new_event.end_date = datetime.datetime.now()

new_event.id = EventDAO().insert(new_event)

pilot1 = Pilot('Pierre', 'Dupont')
pilot2 = Pilot('Pierre', 'Dupond')

new_event.register_pilot(pilot1, 1)
new_event.register_pilot(pilot2, 2)

for bib, competitor in new_event.get_competitors().items():
    CompetitorDAO().insert(competitor)
```