### PR TITLE
Fixes an error when clicking on "Cancel Round" button

### DIFF
--- a/F3FChrono/data/Round.py
+++ b/F3FChrono/data/Round.py
@@ -92,7 +92,6 @@ class Round:
     def cancel_round(self):
         self.valid=False
         self.valid_round_number=None
-        Round.round_counters[self.event] -= 1
         Round.round_dao.update(self)
         self.event.create_new_round(insert_database=True)
         self._current_competitor_index = 0

--- a/F3FChrono/gui/MainUiController.py
+++ b/F3FChrono/gui/MainUiController.py
@@ -160,7 +160,7 @@ class MainUiCtrl (QtWidgets.QMainWindow):
 
     def next_pilot(self, insert_database=False):
         self.controllers['round'].wPilotCtrl.set_data(self.event.get_current_round().next_pilot(insert_database),
-                                                      self.event.get_current_round().round_number)
+                                                      self.event.get_current_round())
         self.controllers['round'].wChronoCtrl.reset_ui()
 
     def refly(self):
@@ -183,7 +183,7 @@ class MainUiCtrl (QtWidgets.QMainWindow):
         self.chronoHard.reset()
         self.chronodata.reset()
         self.controllers['round'].wPilotCtrl.set_data(self.event.get_current_round().get_current_competitor(),
-                                                      self.event.get_current_round().round_number)
+                                                      self.event.get_current_round())
         self.controllers['round'].wChronoCtrl.set_status(self.chronoHard.get_status())
         self.show_chrono()
         self.controllers['round'].wChronoCtrl.reset_ui()
@@ -223,7 +223,7 @@ class MainUiCtrl (QtWidgets.QMainWindow):
     def cancel_round(self):
         self.event.get_current_round().cancel_round()
         self.controllers['round'].wPilotCtrl.set_data(self.event.get_current_round().get_current_competitor(),
-                                                      self.event.get_current_round().round_number)
+                                                      self.event.get_current_round())
         self.chronoHard.reset()
         self.chronodata.reset()
         self.controllers['round'].wChronoCtrl.stoptime()

--- a/F3FChrono/gui/WidgetController.py
+++ b/F3FChrono/gui/WidgetController.py
@@ -179,7 +179,7 @@ class WPilotCtrl():
     def set_data(self, competitor, round):
         self.view.pilotName.setText(competitor.display_name())
         self.view.bib.setText("BIB : "+str(competitor.get_bib_number()))
-        self.view.round.setText("Round : "+str(round))
+        self.view.round.setText("Round : "+str(len(round.event.valid_rounds)+1))
 
 class WChronoCtrl(QTimer):
     btn_null_flight_sig = pyqtSignal()


### PR DESCRIPTION
There was a crash when clicking of "Cancel round" button.
This was due to line 95 of Round.py where the round counters was decreased by 1.

In fact, each round has now a round _number which is in fact its id and a valid_round_number which is what a normal user would expect for a variable named round_number.

This is bad variables naming but changing this is not so easy because database structure must be changed too.