### PR TITLE
Start webserver automatically

### DIFF
--- a/F3FChrono/chrono/ConfigReader.py
+++ b/F3FChrono/chrono/ConfigReader.py
@@ -59,7 +59,8 @@ default_config = \
     "udpport" : 4445,
     "fullscreen":False,
     "buzzer_valid":True,
-    "buzzer_next_valid":True
+    "buzzer_next_valid":True,
+    "run_webserver": False
 }
 
 def init():

--- a/F3FChrono/web/manage.py
+++ b/F3FChrono/web/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'webinterface.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'F3FChrono.web.webinterface.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/F3FChrono/web/webinterface/settings.py
+++ b/F3FChrono/web/webinterface/settings.py
@@ -49,7 +49,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'webinterface.urls'
+ROOT_URLCONF = 'F3FChrono.web.webinterface.urls'
 
 TEMPLATES = [
     {
@@ -67,7 +67,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'webinterface.wsgi.application'
+WSGI_APPLICATION = 'F3FChrono.web.webinterface.wsgi.application'
 
 
 # Database

--- a/F3FChrono/web/webinterface/urls.py
+++ b/F3FChrono/web/webinterface/urls.py
@@ -17,6 +17,6 @@ from django.contrib import admin
 from django.urls import include,path
 
 urlpatterns = [
-    path('f3franking/', include('f3franking.urls')),
+    path('f3franking/', include('F3FChrono.web.f3franking.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/F3FChrono/web/webinterface/wsgi.py
+++ b/F3FChrono/web/webinterface/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'webinterface.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'F3FChrono.web.webinterface.settings')
 
 application = get_wsgi_application()

--- a/config.json
+++ b/config.json
@@ -17,5 +17,6 @@
  "sound": true,
  "udpport": 4445,
  "voice": false,
- "voltage_min": 9.9
+ "voltage_min": 9.9,
+ "run_webserver": false
 }

--- a/runchrono.py
+++ b/runchrono.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import subprocess
 from time import sleep
 from argparse import ArgumentParser
 from PyQt5 import QtWidgets
@@ -35,6 +36,11 @@ def main():
     if(pi['pi']!=''):
         print("warm-up 2 seconds...")
         sleep(2.0)
+
+    if ConfigReader.config.conf['run_webserver']:
+        print("Starting webserver ...")
+        manage_py_path = os.path.realpath('F3FChrono/web')
+        subprocess.Popen(['python3', os.path.join(manage_py_path, 'manage.py'), 'runserver', '0.0.0.0:8000'])
 
     print("...start")
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
      ],
     install_requires=[
-        'pandas', 'requests', 'pymysql',
+        'pandas', 'requests', 'pymysql', 'Django'
     ]
 
  )


### PR DESCRIPTION
This pull request adds the option to start automatically the webserver when running runchrono.py

Finally, it has been done using an external call to python3 command because it proved to be the only working solution.