### PR TITLE
Fix close button

### DIFF
--- a/F3FChrono/gui/MainUiController.py
+++ b/F3FChrono/gui/MainUiController.py
@@ -7,7 +7,6 @@ from F3FChrono.data.dao.EventDAO import EventDAO, RoundDAO
 from F3FChrono.data.Chrono import Chrono
 from F3FChrono.chrono.Sound import *
 from F3FChrono.chrono.GPIOPort import rpi_gpio
-import signal
 
 
 class MainUiCtrl (QtWidgets.QMainWindow):

--- a/F3FChrono/gui/MainUiController.py
+++ b/F3FChrono/gui/MainUiController.py
@@ -350,7 +350,7 @@ class MainUiCtrl (QtWidgets.QMainWindow):
     def shutdown_app(self):
         if self.webserver_process is not None:
             print('Kill process ' + str(self.webserver_process.pid))
-            time.sleep(5)  # Wait for the process to be killed
+            time.sleep(1)  # Wait for the process to be killed
             self.webserver_process.kill()
 
         exit()

--- a/F3FChrono/gui/MainUiController.py
+++ b/F3FChrono/gui/MainUiController.py
@@ -7,13 +7,15 @@ from F3FChrono.data.dao.EventDAO import EventDAO, RoundDAO
 from F3FChrono.data.Chrono import Chrono
 from F3FChrono.chrono.Sound import *
 from F3FChrono.chrono.GPIOPort import rpi_gpio
+import signal
 
 
 class MainUiCtrl (QtWidgets.QMainWindow):
     close_signal = pyqtSignal()
-    def __init__(self, dao, chronodata, rpi):
+    def __init__(self, dao, chronodata, rpi, webserver_process):
         super().__init__()
 
+        self.webserver_process = webserver_process
         self.dao = dao
         self.daoRound = RoundDAO()
         self.event = None
@@ -84,7 +86,7 @@ class MainUiCtrl (QtWidgets.QMainWindow):
         self.controllers['settings'].btn_settingsadvanced_sig.connect(self.show_settingsadvanced)
         self.controllers['settings'].btn_cancel_sig.connect(self.show_config)
         self.controllers['settings'].btn_valid_sig.connect(self.settings_valid)
-        self.controllers['settings'].btn_quitapp_sig.connect(self.close)
+        self.controllers['settings'].btn_quitapp_sig.connect(self.shutdown_app)
         self.controllers['settingsadvanced'].btn_settings_sig.connect(self.show_settings)
         self.controllers['picampair'].btn_valid_sig.connect(self.picampair_valid)
         self.controllers['picampair'].btn_cancel_sig.connect(self.show_config)
@@ -344,6 +346,14 @@ class MainUiCtrl (QtWidgets.QMainWindow):
     def closeEvent(self, event):
         self.close_signal.emit()
         event.accept()
+
+    def shutdown_app(self):
+        if self.webserver_process is not None:
+            print('Kill process ' + str(self.webserver_process.pid))
+            time.sleep(5)  # Wait for the process to be killed
+            self.webserver_process.kill()
+
+        exit()
 
 def main ():
 

--- a/runchrono.py
+++ b/runchrono.py
@@ -31,11 +31,14 @@ def get_raspi_revision():
 
 def main():
 
+    use_popen_shell = True
+
     #logging.basicConfig (filename="runchrono.log", level=logging.DEBUG, format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
     pi=get_raspi_revision()
     if(pi['pi']!=''):
         print("warm-up 2 seconds...")
         sleep(2.0)
+        use_popen_shell = False
 
     webserver_process = None
 
@@ -44,7 +47,7 @@ def main():
         manage_py_path = os.path.realpath('F3FChrono/web')
         webserver_process = \
             subprocess.Popen(['python3', os.path.join(manage_py_path, 'manage.py'), 'runserver', '0.0.0.0:8000'],
-                             shell=True)
+                             shell=use_popen_shell)
 
     print("...start")
 

--- a/runchrono.py
+++ b/runchrono.py
@@ -37,10 +37,14 @@ def main():
         print("warm-up 2 seconds...")
         sleep(2.0)
 
+    webserver_process = None
+
     if ConfigReader.config.conf['run_webserver']:
         print("Starting webserver ...")
         manage_py_path = os.path.realpath('F3FChrono/web')
-        subprocess.Popen(['python3', os.path.join(manage_py_path, 'manage.py'), 'runserver', '0.0.0.0:8000'])
+        webserver_process = \
+            subprocess.Popen(['python3', os.path.join(manage_py_path, 'manage.py'), 'runserver', '0.0.0.0:8000'],
+                             shell=True)
 
     print("...start")
 
@@ -49,7 +53,7 @@ def main():
 
 
     app = QtWidgets.QApplication(sys.argv)
-    ui=MainUiCtrl(dao, chronodata, rpi=pi['pi'])
+    ui=MainUiCtrl(dao, chronodata, rpi=pi['pi'], webserver_process=webserver_process)
 
     #launched simulate mode
     if (ConfigReader.config.conf['simulatemode']):


### PR DESCRIPTION
This fix is still not perfect.

It works perfectly on my computer. If webserver option has been selected, it is able to kill the webserver when closing the app.

On the raspberry I am not able to start the server using shell=True option of Popen command and the close button is able to close the application, but the webserver is still running.

I think it is better than the previous situation because we are able to shutdown or reboot the pi from the touch screen.