### PR TITLE
Fix #72 Event creation fails for F3F Lemoncello CUP

### DIFF
--- a/F3FChrono/data/Round.py
+++ b/F3FChrono/data/Round.py
@@ -32,9 +32,11 @@ class Round:
         if add_initial_group:
             f3f_round.groups.append(RoundGroup(f3f_round, 1))
 
-        for bib in range(event.bib_start, event.get_nb_competitors()+1):
+        for bib in [competitor.bib_number for key, competitor in event.competitors.items()
+                    if competitor.bib_number >= event.bib_start]:
             f3f_round._flight_order += [bib]
-        for bib in range(1, event.bib_start):
+        for bib in [competitor.bib_number for key, competitor in event.competitors.items()
+                    if competitor.bib_number < event.bib_start]:
             f3f_round._flight_order += [bib]
         #print(f3f_round._flight_order)
         return f3f_round

--- a/F3FChrono/data/Round.py
+++ b/F3FChrono/data/Round.py
@@ -32,11 +32,11 @@ class Round:
         if add_initial_group:
             f3f_round.groups.append(RoundGroup(f3f_round, 1))
 
-        for bib in [competitor.bib_number for key, competitor in event.competitors.items()
-                    if competitor.bib_number >= event.bib_start]:
+        for bib in [bib_number for bib_number in sorted(event.competitors)
+                    if bib_number >= event.bib_start]:
             f3f_round._flight_order += [bib]
-        for bib in [competitor.bib_number for key, competitor in event.competitors.items()
-                    if competitor.bib_number < event.bib_start]:
+        for bib in [bib_number for bib_number in sorted(event.competitors)
+                    if bib_number < event.bib_start]:
             f3f_round._flight_order += [bib]
         #print(f3f_round._flight_order)
         return f3f_round


### PR DESCRIPTION
The problem was due to missing bib numbers in the fly order.
This pull request fixes the creation of new round.

The F3F Lemoncello contest can now be imported. However, it seems that 25 rounds are present in F3XVault database instead of 18. It seems there is no mean to detect that the rounds>18 are not valid (instead the fact that there is no valid runs in these rounds).

For the moment, I consider this import as successfull. The user will be able to cancel these additional rounds in management view if needed.