### PR TITLE
Fix add_run when flight is not valid

### DIFF
--- a/F3FChrono/data/RoundGroup.py
+++ b/F3FChrono/data/RoundGroup.py
@@ -115,7 +115,8 @@ class RoundGroup:
         if insert_database:
             run_id, chrono_id = RoundGroup.rundao.insert(run)
             run.id = run_id
-            run.chrono.id = chrono_id
+            if run.chrono is not None:
+                run.chrono.id = chrono_id
 
     def get_valid_run(self, competitor):
         if competitor in self.runs:


### PR DESCRIPTION
This bug was introduced by group scoring feature implementation.
If the run is not valid, there is no chrono.

Testing done :
* give refly to a pilot both when group scoring is enabled / disabled
* give 0 to a pilot when group scoring is enabled / disabled