### PR TITLE
Fix wireless button as Next button

### DIFF
--- a/F3FChrono/chrono/GPIOPort.py
+++ b/F3FChrono/chrono/GPIOPort.py
@@ -160,10 +160,10 @@ class rpi_gpio(QObject):
 
     def btn_next_action(self, port):
         if port==ConfigReader.config.conf['btn_next']:
-            GPIO.remove_event_detect(port)
             self.signal_btn_next.emit()
 
     def btn_next_event(self):
+        GPIO.remove_event_detect(ConfigReader.config.conf['btn_next'])
         self.btnNext_Timer.start(200)
         
     def btn_next_check(self):

--- a/F3FChrono/chrono/UDPReceive.py
+++ b/F3FChrono/chrono/UDPReceive.py
@@ -165,7 +165,7 @@ class udpreceive(QThread):
         if find and (base == "baseA" or base == "baseB"):
             self.event_chrono.emit("udpreceive", "event", base)
         elif find and base == "btn_next":
-            self.event_btn_next.emit(0)
+            self.event_btn_next.emit()
         elif find and base == "switch_mode":
             self.switchMode_sig.emit()
         elif find and base == "penalty":


### PR DESCRIPTION
* Fix parameter count in event_btn_next.emit()

* Disable GPIO in btn_next_event(self) instead of btn_next_action so that it is executed both from normal next button as well as wireless next button

**Please review this carefully as I am not sure how the rebound protection works.**