### PR TITLE
Fix reading data with multiple spaces

### DIFF
--- a/F3FChrono/chrono/UDPReceive.py
+++ b/F3FChrono/chrono/UDPReceive.py
@@ -114,7 +114,7 @@ class udpreceive(QThread):
                 if self.__debug:
                     print(data, address)
                 dt = time.time()
-                m = re.split(r'\s', data.decode('utf-8'))
+                m = data.decode('utf-8').split()
                 if (m[0] == 'terminated'):
                     self.terminate()
                     break


### PR DESCRIPTION
Split command on a string can manage multiple spaces in a string.
It is more convenient to use.

Testing done :
- tested that it works with both anemometer and windvane