### PR TITLE
fix udpsend creation with no network

### DIFF
--- a/F3FChrono/Utils.py
+++ b/F3FChrono/Utils.py
@@ -41,22 +41,6 @@ def is_running_on_pi():
     pi = get_raspi_revision()
     return pi['pi'] != ''
 
-def get_ip():
-    import itertools
-    import os
-    import re
-
-
-    ip = []
-    broadcast = []
-    f = os.popen('ifconfig')
-    for iface in [' '.join(i) for i in
-                  iter(lambda: list(itertools.takewhile(lambda l: not l.isspace(), f)), [])]:
-        int = re.findall('^(eth?|wlan?|enp?|wlps?)[0-9]', iface)
-        if int and re.findall('RUNNING', iface):
-            ip.append(re.findall(r'(?<=inet\s)[\d.-]+', iface)[0])
-            broadcast.append(re.findall(r'(?<=broadcast\s)[\d.-]+', iface)[0])
-    return ip, broadcast
 
 def get_ip():
     import itertools
@@ -73,8 +57,10 @@ def get_ip():
         if int and re.findall('RUNNING', iface):
             ip.append(re.findall(r'(?<=inet\s)[\d.-]+', iface)[0])
             broadcast.append(re.findall(r'(?<=broadcast\s)[\d.-]+', iface)[0])
-    index = 0
     if len(broadcast)>0:
+        index = 0
         if "192.168.1.251" in ip:
             index = ip.index("192.168.1.251")
-    return ip[index], broadcast[index]
+        return ip[index], broadcast[index]
+    else:
+        return None, None

--- a/F3FChrono/chrono/UDPSend.py
+++ b/F3FChrono/chrono/UDPSend.py
@@ -50,30 +50,34 @@ class udpsend(QObject):
         del self.sock
 
     def sendEvent(self):
-        try:
-            self.sock.sendto(bytes('event', 'utf-8'), (self.udpip, self.port))
-        except Exception as error:
-            print("udpsendEvent error : ", error)
+        if self.udpip is not None:
+            try:
+                self.sock.sendto(bytes('event', 'utf-8'), (self.udpip, self.port))
+            except Exception as error:
+                print("udpsendEvent error : ", error)
 
 
     def sendData(self, data):
-        try:
-            self.sock.sendto(bytes(data, 'utf-8'), (self.udpip, self.port))
-        except Exception as error:
-            print("udpsendData error : ", error)
+        if self.udpip is not None:
+            try:
+                self.sock.sendto(bytes(data, 'utf-8'), (self.udpip, self.port))
+            except Exception as error:
+                print("udpsendData error : ", error)
 
     def sendOrderData(self, data):
-        try:
-            self.sock.sendto(bytes((RACEORDERMSG+ ' '+ data), 'utf-8'), (self.udpip, self.port))
-        except Exception as error:
-            print("udpsendOrderData error : ", error)
+        if self.udpip is not None:
+            try:
+                self.sock.sendto(bytes((RACEORDERMSG+ ' '+ data), 'utf-8'), (self.udpip, self.port))
+            except Exception as error:
+                print("udpsendOrderData error : ", error)
 
     def terminate(self):
         print('terminated event')
-        try:
-            self.sock.sendto(bytes('terminated', 'utf-8'), (self.udpip, self.port))
-        except Exception as error:
-            print("udpsendTerminate error : ", error)
+        if self.udpip is not None:
+            try:
+                self.sock.sendto(bytes('terminated', 'utf-8'), (self.udpip, self.port))
+            except Exception as error:
+                print("udpsendTerminate error : ", error)
 
 if __name__ == '__main__':
     print ("UDP Beep Debug")

--- a/F3FChrono/chrono/weather.py
+++ b/F3FChrono/chrono/weather.py
@@ -52,7 +52,7 @@ class anemometer(QObject):
         self.udpSend.sendData("anemometerConnect " + index)
 
 class Weather(QTimer):
-    #parameters : value, unity
+    #parameters : value, unit
     windspeed_signal = pyqtSignal(float, str)
     #parameters : direction, accu voltage
     winddir_signal = pyqtSignal(float, float)


### PR DESCRIPTION
It was reported by Georg that the program fails to start when there is no network.
![image](https://user-images.githubusercontent.com/23299600/180072404-f0b854c3-9883-4597-9114-1605c1dbbabc.png)

Fix this by recuring the get_ip() function to return None when there is no network.
In udpSend, don't send any message when udpsend ip is None.

Testing done :
- On the raspberry, disable the network and launch the application